### PR TITLE
fix gcc-6.4 compilation error

### DIFF
--- a/Src/IndexSA/_MonoCorpus.cpp
+++ b/Src/IndexSA/_MonoCorpus.cpp
@@ -156,7 +156,7 @@ void C_MonoCorpus::loadCorpusAndSort(const char *fileName, const char * idVocFil
 	ifstream textStream1;
 	textStream1.open(fileName);
 
-	if(textStream1==NULL){
+	if(!textStream1){
 		fprintf(stderr,"Text %s does not exist. Exit!\n",fileName);
 		exit(-1);
 	}

--- a/Src/Utils/_UniversalVocabulary.cpp
+++ b/Src/Utils/_UniversalVocabulary.cpp
@@ -40,7 +40,7 @@ void C_UniversalVocabulary::updateWithNewCorpus(const char * newCorpusFileName)
 	ifstream textStream;
 	textStream.open(newCorpusFileName);
 
-	if(textStream==NULL){
+	if(!textStream){
 		fprintf(stderr,"Corpus file %s does not exist. Exit!\n",newCorpusFileName);
 		exit(-1);
 	}


### PR DESCRIPTION
solution from stack overflow, e.g.
<https://stackoverflow.com/questions/32589155/stdofstream-null-wont-compile-for-std-gnu11-any-workaround>